### PR TITLE
Recognize an executable without symbols

### DIFF
--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -322,7 +322,7 @@ func (b *binrep) openELF(name string, start, limit, offset uint64) (plugin.ObjFi
 		// someone passes a kernel path that doesn't contain "vmlinux" AND
 		// (2) _stext is page-aligned AND (3) _stext is not at Vaddr
 		symbols, err := ef.Symbols()
-		if err != nil {
+		if err != nil && err != elf.ErrNoSymbols {
 			return nil, err
 		}
 		for _, s := range symbols {


### PR DESCRIPTION
When a binary provided to pprof has no symbols, it is not recognized as a binary. This happens because the err value is only checked against 'nil'.

This PR fixes this issue by checking the err value against elf.ErrNoSymbols in addition to nil.